### PR TITLE
Add in post-stop

### DIFF
--- a/jobs/nfstestserver/spec
+++ b/jobs/nfstestserver/spec
@@ -4,6 +4,7 @@ name: nfstestserver
 templates:
   install.erb: bin/pre-start
   ctl.erb: bin/nfstestserver_ctl
+  post-start.erb: bin/post-start
 
 packages: []
 

--- a/jobs/nfstestserver/spec
+++ b/jobs/nfstestserver/spec
@@ -4,7 +4,7 @@ name: nfstestserver
 templates:
   install.erb: bin/pre-start
   ctl.erb: bin/nfstestserver_ctl
-  post-start.erb: bin/post-start
+  post-stop.erb: bin/post-stop
 
 packages: []
 

--- a/jobs/nfstestserver/templates/post-stop.erb
+++ b/jobs/nfstestserver/templates/post-stop.erb
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+# Check the paths from /etc/exports matching /export and unmount them
+for path in $(cat /etc/exports | grep export | awk '{ print $1 }')
+do
+  umount "${path}"
+done
+


### PR DESCRIPTION
This patch adds in the `umount` command for unmounting the NFS paths
manually before BOSH attempts to detach the volumes.

h/t @sharms